### PR TITLE
Replace deprec. before_filter with before_action

### DIFF
--- a/test/action_controller/serialization_scope_name_test.rb
+++ b/test/action_controller/serialization_scope_name_test.rb
@@ -12,7 +12,7 @@ class DefaultScopeNameTest < ActionController::TestCase
   class UserTestController < ActionController::Base
     protect_from_forgery
 
-    before_filter { request.format = :json }
+    before_action { request.format = :json }
 
     def current_user
       User.new(id: 1, name: 'Pete', admin: false)
@@ -43,7 +43,7 @@ class SerializationScopeNameTest < ActionController::TestCase
     protect_from_forgery
 
     serialization_scope :current_admin
-    before_filter { request.format = :json }
+    before_action { request.format = :json }
 
     def current_admin
       User.new(id: 2, name: 'Bob', admin: true)


### PR DESCRIPTION
Removes Rails 5.1 Deprecation Warnings
